### PR TITLE
Workflow: Adicionado arquivo CNAME para configuração do domínio

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,3 +55,4 @@ jobs:
         env:
           # @see https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAGES_CNAME: ceruttimaicon.js.org


### PR DESCRIPTION
## O que?
Adicionado arquivo de configuração CNAME ao projeto

## Por que?
É necessário que ele seja criado no deploy da aplicação pelo GitHub Actions para que ele redirecione para o dominio `ceruttimaicon.js.org`

> Obs: Não fazer isso faz com que a página estática fique caindo no github pages