### PR TITLE
Workflow: Ajuste comando workflow para criar arquivo CNAME

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,4 +55,7 @@ jobs:
         env:
           # @see https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PAGES_CNAME: ceruttimaicon.js.org
+      
+      # run build script
+      - name: Create file CNAME
+        run: echo 'ceruttimaicon.js.org' > CNAME


### PR DESCRIPTION
## O que?
Ajustado comando de deploy para criar arquivo CNAME

## Por que?
É necessário ter esse arquivo nos comandos do deploy para ter o redirecionamento de domínio correto