### PR TITLE
Sistema: Adicionado botão de atalho para a página de documentação do vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -35,6 +35,7 @@ module.exports = {
           '/docs/python',
           '/docs/sonarqube',
           '/docs/vue-js',
+          '/docs/vuepress',
         ],
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-ceruttimaicon.github.io",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Projeto de documentaçao de comandos e metodologias uteis",
   "repository": "git@github.com:CeruttiMaicon/project-ceruttimaicon.github.io.git",
   "author": "Maicon Cerutti <dev.cerutti.maicon@gmail.com>",


### PR DESCRIPTION
Close #48

> - [x] Lembrete: Em hotfix'es ajustar o package.json com a versão

### O que?

Adicionado botão de atalho para documentações do vuepress

### Por quê?

Sem este atalho a página fica inacessível.

### Como?

Adicionado ao arquivo de configuração a opção com o atalho da página.

### Capturas de tela

![image](https://user-images.githubusercontent.com/25940408/152445677-ea34f4aa-9ca3-417e-94b7-16925661d235.png)

### Verificações
- [x] HOTFIX Verificar versão no PACKAGE.JSON
